### PR TITLE
Updating the parser to accept empty TTL values

### DIFF
--- a/lib/ex_aws/route53/parsers.ex
+++ b/lib/ex_aws/route53/parsers.ex
@@ -85,7 +85,7 @@ if Code.ensure_loaded?(SweetXml) do
           values: ~x"./ResourceRecords/ResourceRecord/Value/text()"sl,
           set_identifier: ~x"./SetIdentifier/text()"so,
           traffic_policy_instance_id: ~x"./TrafficPolicyInstanceId/text()"so,
-          ttl: ~x"./TTL/text()"i,
+          ttl: ~x"./TTL/text()"io,
           type: ~x"./Type/text()"s,
           weight: ~x"./Weight/text()"Io
         ]

--- a/test/lib/route53/parsers_test.exs
+++ b/test/lib/route53/parsers_test.exs
@@ -237,4 +237,80 @@ defmodule ExAws.Route53.ParsersTest do
       ]
     }
   end
+
+  test "parsing a list resource record sets with no TTL" do
+    rsp = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <ListResourceRecordSetsResponse>
+       <IsTruncated>true</IsTruncated>
+       <MaxItems>21</MaxItems>
+       <NextRecordIdentifier>NEXT_IDENTIFIER</NextRecordIdentifier>
+       <NextRecordName>NEXT_NAME</NextRecordName>
+       <NextRecordType>NEXT_TYPE</NextRecordType>
+       <ResourceRecordSets>
+          <ResourceRecordSet>
+             <AliasTarget>
+                <DNSName>ALIAS_NAME</DNSName>
+                <EvaluateTargetHealth>ALIAS_EVALUATE_TARGET_HEALTH</EvaluateTargetHealth>
+                <HostedZoneId>ALIAS_HOSTED_ZONE_ID</HostedZoneId>
+             </AliasTarget>
+             <Failover>FAILOVER</Failover>
+             <GeoLocation>
+                <ContinentCode>CONTINENT_CODE</ContinentCode>
+                <CountryCode>COUNTRY_CODE</CountryCode>
+                <SubdivisionCode>SUBDIVISION_CODE</SubdivisionCode>
+             </GeoLocation>
+             <HealthCheckId>HEALTH_CHECK_ID</HealthCheckId>
+             <Name>NAME</Name>
+             <Region>REGION</Region>
+             <ResourceRecords>
+                <ResourceRecord>
+                   <Value>VALUE_1</Value>
+                </ResourceRecord>
+                <ResourceRecord>
+                   <Value>&quot;v=spf1 include:mailgun.org ~all&quot;</Value>
+                </ResourceRecord></ResourceRecords>
+             <SetIdentifier>SET_IDENTIFIER</SetIdentifier>
+             <TrafficPolicyInstanceId>TRAFFIC_POLICY_INSTANCE_ID</TrafficPolicyInstanceId>
+             <TTL></TTL>
+             <Type>NS</Type>
+             <Weight>100</Weight>
+          </ResourceRecordSet></ResourceRecordSets>
+    </ListResourceRecordSetsResponse>
+    """
+    |> to_success
+
+    {:ok, %{body: parsed_doc}} = Parsers.parse(rsp, :list_record_sets)
+    assert parsed_doc == %{
+      is_truncated: true,
+      max_items: 21,
+      next_record_identifier: "NEXT_IDENTIFIER",
+      next_record_name: "NEXT_NAME",
+      next_record_type: "NEXT_TYPE",
+      record_sets: [
+        %{
+          alias_target: %{
+            dns_name: "ALIAS_NAME",
+            evaluate_target_health: "ALIAS_EVALUATE_TARGET_HEALTH",
+            hosted_zone_id: "ALIAS_HOSTED_ZONE_ID"
+          },
+          failover: "FAILOVER",
+          geo_location: %{
+            continent_code: "CONTINENT_CODE",
+            country_code: "COUNTRY_CODE",
+            subdivision_code: "SUBDIVISION_CODE"
+          },
+          health_check_id: "HEALTH_CHECK_ID",
+          name: "NAME",
+          region: "REGION",
+          values: ["VALUE_1", "\"v=spf1 include:mailgun.org ~all\""],
+          set_identifier: "SET_IDENTIFIER",
+          traffic_policy_instance_id: "TRAFFIC_POLICY_INSTANCE_ID",
+          ttl: nil,
+          type: "NS",
+          weight: 100
+        }
+      ]
+    }
+  end
 end


### PR DESCRIPTION
When running the parser in my local environment I found that TTL values can sometimes be empty causing the xml parser to break. This updates the parser to make the TTL optional.