### PR TITLE
Correct case on xmlns attributes

### DIFF
--- a/lib/ex_aws/route53.ex
+++ b/lib/ex_aws/route53.ex
@@ -8,6 +8,8 @@ defmodule ExAws.Route53 do
   """
   @type record_type :: [:a | :aaaa | :cname | :mx | :naptr | :ns | :ptr | :soa | :spf | :srv | :txt]
 
+  @xmlns "https://route53.amazonaws.com/doc/2013-04-01/"
+
   @type list_hosted_zones_opts :: [
     {:marker, binary} |
     {:max_items, 1..100}
@@ -30,7 +32,7 @@ defmodule ExAws.Route53 do
   @spec create_hosted_zone(opts :: create_hosted_zone_opts) :: ExAws.Operation.RestQuery.t
   def create_hosted_zone(opts \\ []) do
     payload = {
-      :CreateHostedZoneRequest, %{Xmlns: "https://route53.amazonaws.com/doc/2013-04-01/"}, [
+      :CreateHostedZoneRequest, %{xmlns: @xmlns}, [
        {:CallerReference, nil, uuid()},
        {:Name, nil, opts[:name]}]
     } |> add_optional_node({:DelegationSetId, nil, opts[:delegation_set]})
@@ -74,7 +76,7 @@ defmodule ExAws.Route53 do
   def change_record_sets(id, opts \\ []) do
     changes = opts |> Keyword.get(:batch, Map.new(opts)) |> List.wrap
     payload = {
-      :ChangeResourceRecordSetsRequest, %{Xmlns: "https://route53.amazonaws.com/doc/2013-04-01/"},[
+      :ChangeResourceRecordSetsRequest, %{xmlns: @xmlns},[
        {:ChangeBatch, nil, [
          {:Changes, nil, [
            changes |> Enum.map(fn(change) ->


### PR DESCRIPTION
XML is case-sensitive, so declaring a default namespace via `Xmlns` is
different than `xmlns`. AWS refuses to recognize the capitalized
namespace declaration.

I apologize in advance for the tests; I don't like to submit code with no new tests, but I'm pretty green on XML and I could not figure out how to assert on the namespace of a document in a reasonable amount of time. I also moved the xmlns URL to the top of the file to make it more visible.